### PR TITLE
PowerShell script to export plain text content from Notion pages

### DIFF
--- a/NotionExporter.Cli/Examples/notion-database-content-export.ps1
+++ b/NotionExporter.Cli/Examples/notion-database-content-export.ps1
@@ -1,0 +1,61 @@
+﻿<#
+    .DESCRIPTION
+    Exports a database content
+#>
+
+param (
+    [string]$Token,
+    [string]$DatabaseId,
+    [string]$ExporterPath = ".\NotionExporter.cli.exe",
+    [switch]$Help,
+    [switch]$Usage
+)
+
+function Show-Help
+{
+    Write-Host "notion-database-content-export.ps1" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "Usage:"
+    Write-Host "  .\notion-database-content-export.ps1 -Token <Token> -DatabaseId <ID> [-ExporterPath <path>]"
+    Write-Host ""
+    Write-Host "Parameters:"
+    Write-Host "  -Token          Notion API token"
+    Write-Host "  -DatabaseId     ID of the Notion database to export from (required)"
+    Write-Host "  -ExporterPath   Path to NotionExporter.cli.exe (default: .\NotionExporter.cli.exe)"
+    Write-Host "  -Help, -Usage   Show this help message"
+    Write-Host ""
+}
+
+if ($Help -or $Usage -or [string]::IsNullOrWhiteSpace($DatabaseId))
+{
+    Show-Help
+    return
+}
+
+$filterJson = @"
+{"filter":{"property":"Date","date":{"this_week":{}}}}
+"@
+
+$pageIds = .\NotionExporter.Cli.exe databases --token $Token --id $DatabaseId --filter-json $filterJson |
+    ConvertFrom-Json |
+    ForEach-Object { $_.results } |
+    ForEach-Object { $_.id }
+
+foreach ($pageId in $pageIds)
+{
+    Write-Host "Exporting blocks for page ID: $pageId" -ForegroundColor Cyan
+    
+    $json = .\NotionExporter.Cli.exe blocks --token $token --id $pageId | ConvertFrom-Json
+
+    foreach ($block in $json.results)
+    {
+        $type = $block.type
+        if ($block.$type -and $block.$type.rich_text)
+        {
+            foreach ($t in $block.$type.rich_text)
+            {
+                $t.plain_text
+            }
+        }
+    }
+}

--- a/NotionExporter.Cli/Examples/notion-database-export.ps1
+++ b/NotionExporter.Cli/Examples/notion-database-export.ps1
@@ -5,7 +5,7 @@
 
 param (
     [string]$DatabaseId,
-    [string]$ExporterPath = ".\NotionExporter.exe",
+    [string]$ExporterPath = ".\NotionExporter.cli.exe",
     [switch]$Help,
     [switch]$Usage
 )
@@ -19,7 +19,7 @@ function Show-Help
     Write-Host ""
     Write-Host "Parameters:"
     Write-Host "  -DatabaseId     ID of the Notion database to export from (required)"
-    Write-Host "  -ExporterPath   Path to NotionExporter.exe (default: .\NotionExporter.exe)"
+    Write-Host "  -ExporterPath   Path to NotionExporter.cli.exe (default: .\NotionExporter.cli.exe)"
     Write-Host "  -Help, -Usage   Show this help message"
     Write-Host ""
 }

--- a/NotionExporter.Cli/Examples/notion-page-export.ps1
+++ b/NotionExporter.Cli/Examples/notion-page-export.ps1
@@ -5,7 +5,7 @@
 
 param (
     [string]$PageId,
-    [string]$ExporterPath = ".\NotionExporter.exe",
+    [string]$ExporterPath = ".\NotionExporter.cli.exe",
     [switch]$Help,
     [switch]$Usage
 )
@@ -19,7 +19,7 @@ function Show-Help
     Write-Host ""
     Write-Host "Parameters:"
     Write-Host "  -PageId         ID of the Notion page to export from (required)"
-    Write-Host "  -ExporterPath   Path to NotionExporter.exe (default: .\NotionExporter.exe)"
+    Write-Host "  -ExporterPath   Path to NotionExporter.cli.exe (default: .\NotionExporter.cli.exe)"
     Write-Host "  -Help, -Usage   Show this help message"
     Write-Host ""
 }

--- a/NotionExporter.Cli/NotionExporter.Cli.csproj
+++ b/NotionExporter.Cli/NotionExporter.Cli.csproj
@@ -8,6 +8,9 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <None Update="Examples\notion-database-content-export.ps1">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
         <None Update="Examples\notion-database-export.ps1">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
@@ -17,12 +20,13 @@
         <None Update="appsettings.json">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+        <None Include="bin\Debug\net9.0\Examples\notion-database-content-export.ps1"/>
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\NotionExporter.Applications\NotionExporter.Applications.csproj"/>
-        <ProjectReference Include="..\NotionExporter.Infrastructure\NotionExporter.Infrastructure.csproj" />
-        <ProjectReference Include="..\NotionExporter.Shared\NotionExporter.Shared.csproj" />
+        <ProjectReference Include="..\NotionExporter.Infrastructure\NotionExporter.Infrastructure.csproj"/>
+        <ProjectReference Include="..\NotionExporter.Shared\NotionExporter.Shared.csproj"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -30,10 +34,10 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4"/>
         <PackageReference Include="Spectre.Console.Cli" Version="0.50.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.4"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4"/>
+        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### 📝 PowerShell script to export plain text content from Notion pages

This script automates the process of retrieving Notion page IDs from a database using a filtered query (via --filter-json), and then iterates through each page to extract and output only the plain_text content from its blocks.

**Key features:**

- Uses --filter-json to retrieve only relevant pages (e.g., those from the current week).
- Extracts plain_text from each block regardless of block type (e.g., paragraphs, headings, to-do items, etc.).
- Outputs text directly to stdout, suitable for piping or logging.
- Avoids hardcoded block types by dynamically accessing content based on the type property.

This is useful for creating clean text exports from structured Notion content, e.g. for reporting, backups, or further processing.

Let me know if you’d like to extend this to save the output per-page or in a structured format (Markdown, CSV, etc.).

